### PR TITLE
Fix "TypeError: Cannot read property 'index' of undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ module.exports = stylelint.createPlugin(
           return node;
         });
 
-        if (nodes && transitionProp.length === 0) {
+        if (nodes && nodes.length > 0 && transitionProp.length === 0) {
           stylelint.utils.report({
             ruleName,
             result,


### PR DESCRIPTION
Fix error when referencing index key of nodes[0] when nodes.length = 0