### PR TITLE
Add Stylelint 15 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test": "jest --coverage"
   },
   "peerDependencies": {
-    "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0"
+    "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",


### PR DESCRIPTION
The [significant changes of the v15 release](https://github.com/stylelint/stylelint/blob/main/docs/migration-guide/to-15.md) should not affect this plugin.